### PR TITLE
Fixed typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 ### RGB
 
 ```
-Green  : #67E5AD rbg : 103 229 173
-Violet : #7A67F8 rbg : 122 103 248
-Rose   : #F85977 rbg : 248  89 119
-Blue   : #159BFF rbg :  21 155 255
+Green  : #67E5AD rgb : 103 229 173
+Violet : #7A67F8 rgb : 122 103 248
+Rose   : #F85977 rgb : 248  89 119
+Blue   : #159BFF rgb :  21 155 255
 ```
 
 ### CMYK

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@
 ### RGB
 
 ```
-Green  : #67E5AD rgb : 103 229 173
-Violet : #7A67F8 rgb : 122 103 248
-Rose   : #F85977 rgb : 248  89 119
-Blue   : #159BFF rgb :  21 155 255
+Green  : #67E5AD RGB : 103 229 173
+Violet : #7A67F8 RGB : 122 103 248
+Rose   : #F85977 RGB : 248  89 119
+Blue   : #159BFF RGB :  21 155 255
 ```
 
 ### CMYK
 
 ```
-Green  : #87CEC9 cmyk : 47 0  24 0
-Violet : #8373B1 cmyk : 53 61  0 0
-Rose   : #E0457B cmyk :  4 90 25 0
-Blue   : #00A9E0 cmyk : 75 15  0 0
+Green  : #87CEC9 CMYK : 47 0  24 0
+Violet : #8373B1 CMYK : 53 61  0 0
+Rose   : #E0457B CMYK :  4 90 25 0
+Blue   : #00A9E0 CMYK : 75 15  0 0
 ```
 
 ### PANTONE


### PR DESCRIPTION
RGB colors were listed as rbg instead of rgb, also fixed the capitalization as they are acronyms, and should be all capital letters.