### PR TITLE
Fix incorrect term usage on THIRD-PARTY-NOTICES.md

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,2 +1,2 @@
 
-- `diagrams/xamarin-forms-webassembly-renderer.*` is based off https://forums.xamarin.com/discussion/170673/xamarin-architecture-diagram-updated/ by Xamarin.
+- `diagrams/xamarin-forms-webassembly-renderer.*` is based on https://forums.xamarin.com/discussion/170673/xamarin-architecture-diagram-updated/ by Xamarin.


### PR DESCRIPTION
This PR fixes the grammar on the third party notices file, replacing "based off" for "based on" since the first is an incorrect term. (Check [this link](https://itknowledgeexchange.techtarget.com/writing-for-business/based-off-based-on/) for more details)